### PR TITLE
export needed types from open ai node sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openai-react-native",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "OpenAI React Native API Client without polyfills",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
fixes https://github.com/backmesh/openai-react-native/issues/3

this also renames existing types to prefer `onStreamEvent` over `eventCallback` naming convention 